### PR TITLE
add helper script for running tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ end_of_line = crlf
 charset = utf-8
 trim_trailing_whitespace = false
 insert_final_newline = false
+
+[{*.sh,.editorconfig}]
+end_of_line = lf

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -8,7 +8,7 @@ then
     exit 4
 fi
 
-source ./.env
+. ./.env
 
 # set TEST_REPORTS environment variable to change output directory
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+set -e
+
+if [ ! -f ".env" ]
+then
+    echo "Missing environment file: .env"
+    exit 4
+fi
+
+source ./.env
+
+# set TEST_REPORTS environment variable to change output directory
+
+if [ "$1" == "headless" ]
+then
+    python -m robot.run \
+        -v BROWSER:headlesschrome \
+        -v "EDUUNI_EMAIL_PASSWORD:$EDUUNI_EMAIL_PASSWORD" \
+        -v "API_KEY:$API_KEY" \
+        -v "ENVIRONMENT:$ENVIRONMENT" \
+        -d ${TEST_REPORTS:=test_reports} \
+        tests
+elif [ "$1" == "record" ]
+then
+    python -m robot.run \
+        -v BROWSER:chrome \
+        -v RECORD:True \
+        -v "EDUUNI_EMAIL_PASSWORD:$EDUUNI_EMAIL_PASSWORD" \
+        -v "API_KEY:$API_KEY" \
+        -v "ENVIRONMENT:$ENVIRONMENT" \
+        -d ${TEST_REPORTS:=test_reports} \
+        tests
+elif [ "$1" == "single" ]
+then
+    if [ "$2" == "" ]
+    then
+        echo "Please specify test name"
+        exit 2
+    fi
+
+    python -m robot.run \
+        -v BROWSER:chrome \
+        -v "EDUUNI_EMAIL_PASSWORD:$EDUUNI_EMAIL_PASSWORD" \
+        -v "API_KEY:$API_KEY" \
+        -v "ENVIRONMENT:$ENVIRONMENT" \
+        -d ${TEST_REPORTS:=test_reports} \
+        -t "$2" \
+        tests
+else
+    echo "Usage: $(basename $0) <headless|record|single> [test name]"
+    exit 3
+fi


### PR DESCRIPTION
Examples:

```sh
# run all tests in headless mode
./run_tests.sh headless

# run all tests in record mode, and store reports in ./foo/
TEST_REPORTS=foo ./run_tests.sh record

# run a single test
./run_tests.sh single "T1C13. Create and test INCOMPLETE terminology search page"
```