### PR TITLE
Xpath and other fixes

### DIFF
--- a/resources/selenium keywords/models/terminology/search page.robot
+++ b/resources/selenium keywords/models/terminology/search page.robot
@@ -69,7 +69,7 @@ Clear terminology search
     
 Search and select terminology ${Terminology}
     Search terminology ${Terminology}
-    Click element with wait           //h2[contains(text(), "${Terminology}")]
+    Click element with wait           //h2/span/b[contains(text(), "${Terminology}")]
     Verify page is terminology page
 
 Get status count from ${filter} filter

--- a/resources/selenium keywords/models/terminology/term creation.robot
+++ b/resources/selenium keywords/models/terminology/term creation.robot
@@ -876,7 +876,7 @@ Verify term page does not contain all information
     ...             ${Term conjugation}=${NONE}
     ...             ${Term word class}=${NONE}
     Click element with wait           //span/span/button[text()="${name}"]
-    Wait until page contains element  //h2[text()="${name}"]
+    Wait until page contains element  //h2/span[text()="${name}"]
 
     IF  '${homograph}' != '${NONE}'
         Wait until page does not contain element  ${homograph in term information title}

--- a/resources/selenium keywords/models/terminology/terminology page.robot
+++ b/resources/selenium keywords/models/terminology/terminology page.robot
@@ -38,7 +38,7 @@ Verify collection ${collection} on terminology ${terminology} does not contain c
     Select terminology ${terminology} from breadcrumps
 
 Select concept ${concept}
-    click element with wait  //h2[text()="${concept}"] 
+    click element with wait  //h2/span[text()="${concept}"] 
 
 Select collection concept ${concept} 
     click element with wait  //a[text()="${concept}"] 

--- a/resources/selenium keywords/models/terminology/terminology_create_dialog.robot
+++ b/resources/selenium keywords/models/terminology/terminology_create_dialog.robot
@@ -34,8 +34,9 @@ Create terminology from dialog
     ...             ${prefix}
     ...             ${email}
     ...             ${another vocabulary}=${NONE}
-    Open create terminology dialog    
-    Click element with wait  ${Select fill information}    
+    Open create terminology dialog  
+    # Radio button select has been disabled for now  
+    # Click element with wait  ${Select fill information}    
 
     IF  '${language}' != '${NONE}'
         Click element with wait  ${Terminology select language input}

--- a/resources/variables/local/urls.robot
+++ b/resources/variables/local/urls.robot
@@ -1,2 +1,3 @@
 *** Variables ***
 ${TERMINOLOGIES_URL}  http://localhost:3000
+${DATAMODELS_URL}     http://localhost:3000

--- a/tests/terminology/terminology_create_concept.robot
+++ b/tests/terminology/terminology_create_concept.robot
@@ -58,7 +58,6 @@ T4C2. Verify concept creation error messages
 
     Verify concept error message ${Admin note missing error}
     Verify concept error message ${Note missing error}
-    Verify concept error message ${Status missing error}
     Verify concept error message ${Example missing error} 
     Verify concept error message ${Source missing error} 
     Verify concept error message ${Url missing error}

--- a/tests/terminology/terminology_search_page_main.robot
+++ b/tests/terminology/terminology_search_page_main.robot
@@ -25,7 +25,7 @@ T1C2. Test status filter checkbox and buttons
     ...     BETA
     Open terminology search page
     Get filter counts from search page
-    Verify search page contains ${Draft + Valid + retired + Superseded count} items with filters
+    Verify search page contains ${Draft + Valid count} items with filters
     
     Set filter Voimassa oleva checkbox
     Verify search page contains ${Valid count} items with filters
@@ -85,7 +85,7 @@ T1C2. Test status filter checkbox and buttons
     Verify page does not contain terminologies with status Poistettu käytöstä
     Verify filters are defaults
     
-    Verify search page contains ${Draft + Valid + retired + Superseded count} items with filters
+    Verify search page contains ${Draft + Valid count} items with filters
 
 T1C3. Test domain filter checkbox and buttons
     [Tags]  PROD

--- a/tests/terminology/terminology_search_page_terminology.robot
+++ b/tests/terminology/terminology_search_page_terminology.robot
@@ -28,13 +28,13 @@ T2C2. Terminology page filter checkbox and buttons tests
     Select first terminology on list
     Get filter counts from search page
 
-    Verify concepts search page contains ${Draft + Valid + Superseded + Retired count} items with filters
+    Verify concepts search page contains ${Draft + Valid count} items with filters
 
     Verify filter Voimassa oleva with checkbox and search count ${Valid count}
     Verify filter Luonnos with checkbox and search count ${Draft count}
     Verify filter Korvattu with checkbox and search count ${Superseded count}
     Verify filter Poistettu käytöstä with checkbox and search count ${Retired count}
-    Verify concepts search page contains ${Draft + Valid + Superseded + Retired count} items with filters
+    Verify concepts search page contains ${Draft + Valid count} items with filters
 
     Set filter Voimassa oleva checkbox
     Set filter Luonnos checkbox
@@ -47,7 +47,7 @@ T2C2. Terminology page filter checkbox and buttons tests
     Verify filter Korvattu with buttons and search count ${Superseded count}
     Verify filter Poistettu käytöstä with buttons and search count ${Retired count}
 
-    Verify concepts search page contains ${Draft + Valid + Superseded + Retired count} items with filters
+    Verify concepts search page contains ${Draft + Valid count} items with filters
 
 T2C3. Test and create terminology with concepts
     Create terminology with api     ${DEFAULT TERMINOLOGY NAME}


### PR DESCRIPTION
- Fix xpath from search results 
- Fix counts in terminology and concept search (by default only valids and drafts are visible)
- Remove redundant error message for missing status