### PR TITLE
Fix setup and modify terminology test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+selenium==4.9.1
 robotframework==5.0
 robotframework-seleniumlibrary==6.0.0
 robotframework-screencaplibrary==1.6.0

--- a/resources/selenium keywords/models/terminology/terminology page.robot
+++ b/resources/selenium keywords/models/terminology/terminology page.robot
@@ -91,6 +91,7 @@ Download terminology
 Open modify terminology dialog
     Open terminology information
     Click element with wait            ${Terminology modify button}
+    Sleep   3
 
 Open create terminology dialog
     Click element with wait  ${Create terminology button}  

--- a/tests/terminology/terminology_modify_terminology.robot
+++ b/tests/terminology/terminology_modify_terminology.robot
@@ -93,7 +93,7 @@ T7C2. Modify terminology
     Verify displayed domains are Asuminen, Demokratia
     Verify displayed organizations are Automaatiotestaus
     Verify displayed organizations are Testiorganisaatio
-    Verify displayed languages are suomi FI, englanti EN, ruotsi SV
+    Verify displayed languages are suomi FI, ruotsi SV, englanti EN
     Verify displayed type is Muu sanasto
     # TODO bug prefix modify does not work
     #Verify displayed url contains ${DEFAULT TERMINOLOGY PREFIX}_1


### PR DESCRIPTION
- Downgrade selenium to 4.9.1 because of error `TypeError: __init__() got an unexpected keyword argument 'service_log_path'`
- Fix modify terminology test: add some delay after edit view opens so the language list will get populated. Fix language display order 