### PR TITLE
YTI-4381 - Bring robot tests up to date

### DIFF
--- a/resources/api keywords/common_api_resouces.py
+++ b/resources/api keywords/common_api_resouces.py
@@ -8,3 +8,44 @@ def parse_comment_round_urls_with_label(json, label):
 def parse_terminology_urls_with_value(json, value):
     terminology_ids = [x["id"] for x in json if x["properties"]["prefLabel"][0]["value"] == value]
     return terminology_ids
+
+
+def find_prefix_from_terminology_search(response_json, label):
+    for result in response_json.get("responseObjects", []):
+        labels = result.get("label", {})
+        if label in labels.values():
+            return result["prefix"]
+    raise ValueError(f"Terminology with label '{label}' not found in search results")
+
+
+def build_terminology_json(prefix, label_fi, status, organization, domain, languages=None):
+    import json
+    if languages is None:
+        languages = ["fi"]
+    return json.dumps({
+        "prefix": prefix,
+        "label": {"fi": label_fi},
+        "languages": languages,
+        "status": status,
+        "organizations": [organization],
+        "groups": [domain],
+        "graphType": "TERMINOLOGICAL_VOCABULARY"
+    })
+
+
+def build_concept_json(identifier, concept_label_fi, status):
+    import json
+    return json.dumps({
+        "identifier": identifier,
+        "status": status,
+        "recommendedTerms": [{"language": "fi", "label": concept_label_fi, "status": status}]
+    })
+
+
+def build_collection_json(identifier, label_fi, members):
+    import json
+    return json.dumps({
+        "identifier": identifier,
+        "label": {"fi": label_fi},
+        "members": list(members) if not isinstance(members, list) else members
+    })

--- a/resources/api keywords/common_api_resouces.py
+++ b/resources/api keywords/common_api_resouces.py
@@ -49,3 +49,11 @@ def build_collection_json(identifier, label_fi, members):
         "label": {"fi": label_fi},
         "members": list(members) if not isinstance(members, list) else members
     })
+
+
+def build_collection_update_json(label_fi, members):
+    import json
+    return json.dumps({
+        "label": {"fi": label_fi},
+        "members": list(members) if not isinstance(members, list) else members
+    })

--- a/resources/api keywords/terminology_api_resouces.robot
+++ b/resources/api keywords/terminology_api_resouces.robot
@@ -16,8 +16,8 @@ ${DOMAIN_HOUSING}=                      P1
 ${ORGANIZATION_AUTOMATION}=             918448ba-3fc1-4908-aae7-096c8773ca8b
 ${ORGANIZATION_TEST}=                   9a7362ab-0938-462c-a645-abae08525715
 
-${CONCEPT_ID_DEFAULT}=                  04bb2206-ba9e-4007-920d-f57ed0d4bcef
-${COLLECTION_ID_DEFAULT}=               85de7936-174a-4b68-8b35-8a2b0ebbd6fd
+${CONCEPT_ID_DEFAULT}=                  concept-1
+${COLLECTION_ID_DEFAULT}=               collection-1
 
 ${DRAFT}=                   DRAFT
 ${VALID}=                   VALID

--- a/resources/api keywords/terminology_api_resouces.robot
+++ b/resources/api keywords/terminology_api_resouces.robot
@@ -29,7 +29,7 @@ ${INCOMPLETE}=              INCOMPLETE
 *** Keywords ***
 Find terminology prefix for ${terminology}
     ${headers}=     Create authentication header
-    ${response}=    Get    ${SEARCH_TERMINOLOGIES_API_POINT}    headers=${headers}    params=query=${terminology}&pageSize=50
+    ${response}=    Get    ${SEARCH_TERMINOLOGIES_API_POINT}    headers=${headers}    params=query=${terminology}&pageSize=50&status=DRAFT&status=VALID&status=SUPERSEDED&status=RETIRED&status=INCOMPLETE
     ${prefix}=      find prefix from terminology search    ${response.json()}    ${terminology}
     [Return]        ${prefix}
 

--- a/resources/api keywords/terminology_api_resouces.robot
+++ b/resources/api keywords/terminology_api_resouces.robot
@@ -72,3 +72,14 @@ Create terminology collection with api
     ${json}=        build collection json    ${collection id}    ${collection}    ${members}
     ${response}=    Post    ${CREATE_TERMI_COLLECTION_API_POINT}/${prefix}    headers=${headers}    data=${json}
     [Return]        ${response}
+
+Update terminology collection with api
+    [Arguments]     ${terminology}
+    ...             ${collection}
+    ...             ${collection id}
+    ...             ${members}
+    ${prefix}=      Find terminology prefix for ${terminology}
+    ${headers}=     Create authentication header
+    ${json}=        build collection update json    ${collection}    ${members}
+    ${response}=    Put    ${CREATE_TERMI_COLLECTION_API_POINT}/${prefix}/${collection id}    headers=${headers}    data=${json}
+    [Return]        ${response}

--- a/resources/api keywords/terminology_api_resouces.robot
+++ b/resources/api keywords/terminology_api_resouces.robot
@@ -3,19 +3,19 @@ Library               RequestsLibrary
 Resource              common_api_resources.robot
 
 *** Variables ***
-${DELETE_TERMINOLOGY_API_POINT}=        ${TERMINOLOGIES_URL}/terminology-api/api/v1/frontend/vocabulary
-${CREATE_TERMINOLOGY_API_POINT}=        ${TERMINOLOGIES_URL}/terminology-api/api/v1/frontend/validatedVocabulary
-${CREATE_TERMI_CONCEPT_API_POINT}=      ${TERMINOLOGIES_URL}/terminology-api/api/v1/frontend/modify
-${GET_TERMINOLOGY_GRAPHS_API_POINT}     ${TERMINOLOGIES_URL}/terminology-api/api/v1/frontend/graphs
-${template_graph_id}=                   61cf6bde-46e6-40bb-b465-9b2c66bf4ad8
+${TERMINOLOGY_API_BASE}=                ${TERMINOLOGIES_URL}terminology-api/v2
+${DELETE_TERMINOLOGY_API_POINT}=        ${TERMINOLOGY_API_BASE}/terminology
+${CREATE_TERMINOLOGY_API_POINT}=        ${TERMINOLOGY_API_BASE}/terminology
+${CREATE_TERMI_CONCEPT_API_POINT}=      ${TERMINOLOGY_API_BASE}/concept
+${CREATE_TERMI_COLLECTION_API_POINT}=   ${TERMINOLOGY_API_BASE}/collection
+${SEARCH_TERMINOLOGIES_API_POINT}=      ${TERMINOLOGY_API_BASE}/frontend/search-terminologies
 
-${DOMAIN_DEMOCRACY}=                    9f69e282-b4d9-3cc0-a0d2-e7ccd861266a
-${DOMAIN_HOUSING}=                      9ba19f8d-d688-39cc-b620-ebb7875e6e9b
+${DOMAIN_DEMOCRACY}=                    P8
+${DOMAIN_HOUSING}=                      P1
 
 ${ORGANIZATION_AUTOMATION}=             918448ba-3fc1-4908-aae7-096c8773ca8b
 ${ORGANIZATION_TEST}=                   9a7362ab-0938-462c-a645-abae08525715
 
-${TERM_ID}=                             bf5f88cb-3a33-498e-b8eb-1c9807973e88
 ${CONCEPT_ID_DEFAULT}=                  04bb2206-ba9e-4007-920d-f57ed0d4bcef
 ${COLLECTION_ID_DEFAULT}=               85de7936-174a-4b68-8b35-8a2b0ebbd6fd
 
@@ -25,20 +25,18 @@ ${SUPERSEDED}=              SUPERSEDED
 ${RETIRED}=                 RETIRED
 ${INCOMPLETE}=              INCOMPLETE
 
+
 *** Keywords ***
-Find terminology id for ${terminology} with api
+Find terminology prefix for ${terminology}
     ${headers}=     Create authentication header
-    ${response}=    Get      ${GET_TERMINOLOGY_GRAPHS_API_POINT}  headers=${headers}
-    @{graphs_ids}=  parse terminology urls with value  ${response.json()}  ${terminology}
-    [Return]  @{graphs_ids}
+    ${response}=    Get    ${SEARCH_TERMINOLOGIES_API_POINT}    headers=${headers}    params=query=${terminology}&pageSize=50
+    ${prefix}=      find prefix from terminology search    ${response.json()}    ${terminology}
+    [Return]        ${prefix}
 
 Delete terminology ${terminology} with api
     ${headers}=     Create authentication header
-    @{graphs_ids}=  Find terminology id for ${terminology} with api
-    FOR    ${graphs_id}    IN    @{graphs_ids}
-        ${data}=        Catenate    graphId=${graphs_id}
-        ${response}=    Delete      ${DELETE_TERMINOLOGY_API_POINT}?${data}  headers=${headers}
-    END
+    ${prefix}=      Find terminology prefix for ${terminology}
+    ${response}=    Delete    ${DELETE_TERMINOLOGY_API_POINT}/${prefix}    headers=${headers}
     [Return]        ${response}
 
 Create terminology with api
@@ -47,121 +45,30 @@ Create terminology with api
     ...             ${domain}=${DOMAIN_HOUSING}
     ...             ${organization}=${ORGANIZATION_AUTOMATION}
     ...             ${prefix}=${terminology}
-
-    ${uuid}         Evaluate    uuid.uuid4()    modules=uuid
-    ${graph_id}=    Catenate
-    ...             ${uuid}
     ${headers}=     Create authentication header
-    ${data}=        Catenate
-    ...             templateGraphId=${template_graph_id}
-    ...             &prefix=${prefix}
-    ${json}=        Create terminology json from file
-    ...             ${JSON_FILE_FOLDER}${/}terminology_create.json
-    ...             ${terminology}
-    ...             ${graph_id}
-    ...             ${template_graph_id}
-    ...             ${status}
-    ...             ${domain}
-    ...             ${organization}
-    ${response}=    Post        ${CREATE_TERMINOLOGY_API_POINT}?${data}    headers=${headers}  data=${json}
+    ${json}=        build terminology json    ${prefix}    ${terminology}    ${status}    ${organization}    ${domain}
+    ${response}=    Post    ${CREATE_TERMINOLOGY_API_POINT}    headers=${headers}    data=${json}
     [Return]        ${response}
 
-Create terminology collection with api  
-    [Arguments]     ${terminology}
-    ...             ${collection}
-    ...             ${collection id}
-    ...             ${members}
-    ${headers}=     Create authentication header
-    @{graphs_ids}=  Find terminology id for ${terminology} with api
-    FOR    ${graphs_id}    IN    @{graphs_ids}
-        ${json}=        Create collection json from file
-        ...             ${JSON_FILE_FOLDER}${/}terminology_collections_create.json
-        ...             ${graphs_id}
-        ...             ${collection}
-        ...             ${collection id}
-        ...             ${members}
-        ${response}=    Post        ${CREATE_TERMI_CONCEPT_API_POINT}   headers=${headers}  data=${json}
-    END
-    [Return]        ${response}
-
-Create terminology concept with api  
+Create terminology concept with api
     [Arguments]     ${terminology}
     ...             ${concept}
     ...             ${concept id}=${CONCEPT_ID_DEFAULT}
     ...             ${status}=${DRAFT}
-    ...             ${term id}=${TERM_ID}
+    ...             ${term id}=${EMPTY}
+    ${prefix}=      Find terminology prefix for ${terminology}
     ${headers}=     Create authentication header
-    
-    @{graphs_ids}=  Find terminology id for ${terminology} with api
-    FOR    ${graphs_id}    IN    @{graphs_ids}
-        ${json}=        Create concept json from file
-        ...             ${JSON_FILE_FOLDER}${/}terminology_concept_create.json
-        ...             ${graphs_id}
-        ...             ${concept}
-        ...             ${concept id}
-        ...             ${status}
-        ...             ${term id}
-        ${response}=    Post        ${CREATE_TERMI_CONCEPT_API_POINT}   headers=${headers}  data=${json}
-    END
+    ${json}=        build concept json    ${concept id}    ${concept}    ${status}
+    ${response}=    Post    ${CREATE_TERMI_CONCEPT_API_POINT}/${prefix}    headers=${headers}    data=${json}
     [Return]        ${response}
 
-Create terminology json from file
-    [Arguments]         ${file}     
-    ...                 ${terminology}      
-    ...                 ${graph_id}     
-    ...                 ${template_graph_id}  
-    ...                 ${status}
-    ...                 ${domain}
-    ...                 ${organization}
-
-    ${json_string}=      Get File    ${file}
-    ${json}=             evaluate        json.loads('''${json_string}''')    json
-    set to dictionary    ${json}                                    id=${graph_id}
-    set to dictionary    ${json["type"]["graph"]}                   id=${template_graph_id}
-    set to dictionary    ${json["properties"]["prefLabel"][0]}      value=${terminology}
-    set to dictionary    ${json["properties"]["status"][0]}         value=${status}
-    set to dictionary    ${json["references"]["contributor"][0]}    id=${organization}
-    set to dictionary    ${json["references"]["inGroup"][0]}        id=${domain}
-    ${json_string}=      evaluate        json.dumps(${json})                 json
-    [Return]        ${json_string}
-
-Create concept json from file
-    [Arguments]         ${file}
-    ...                 ${graphs_id}
-    ...                 ${concept}
-    ...                 ${concept id}
-    ...                 ${status}
-    ...                 ${term id}
-
-    ${json_string}=      Get File    ${file}
-    ${json}=             evaluate        json.loads('''${json_string}''')      json
-    set to dictionary    ${json["save"][1]}                                    id=${concept id}
-    set to dictionary    ${json["save"][0]}                                    id=${term id}
-    set to dictionary    ${json["save"][1]["references"]["prefLabelXl"][0]}    id=${term id}
-    set to dictionary    ${json["save"][1]["references"]["prefLabelXl"][0]["type"]["graph"]}    id=${graphs_id}
-    set to dictionary    ${json["save"][0]["type"]["graph"]}                   id=${graphs_id}
-    set to dictionary    ${json["save"][1]["type"]["graph"]}                   id=${graphs_id}
-    set to dictionary    ${json["save"][0]["properties"]["prefLabel"][0]}      value=${concept}
-    set to dictionary    ${json["save"][0]["properties"]["status"][0]}         value=${status}
-    set to dictionary    ${json["save"][1]["properties"]["status"][0]}         value=${status}
-    ${json_string}=      evaluate        json.dumps(${json})                 json
-    [Return]        ${json_string}
-
-Create collection json from file
-    [Arguments]         ${file}
-    ...                 ${graphs_id}
-    ...                 ${collection}
-    ...                 ${collection id}
-    ...                 ${members}
-
-    ${json_string}=      Get File    ${file}
-    ${json}=             evaluate        json.loads('''${json_string}''')    json
-    set to dictionary    ${json["save"][0]}                                    id=${collection id}
-    set to dictionary    ${json["save"][0]["type"]["graph"]}                   id=${graphs_id}
-    set to dictionary    ${json["save"][0]["properties"]["prefLabel"][0]}      value=${collection}
-    FOR  ${member}  IN  @{members}
-        ${new_member}=       Evaluate   {"id": "${member}","type": {"id": "Concept","graph": {"id": "${graphs_id}"},"uri": ""}}
-        Append To List       ${json["save"][0]["references"]["member"]}     ${new_member}
-    END
-    ${json_string}=      evaluate        json.dumps(${json})                 json
-    [Return]        ${json_string}
+Create terminology collection with api
+    [Arguments]     ${terminology}
+    ...             ${collection}
+    ...             ${collection id}
+    ...             ${members}
+    ${prefix}=      Find terminology prefix for ${terminology}
+    ${headers}=     Create authentication header
+    ${json}=        build collection json    ${collection id}    ${collection}    ${members}
+    ${response}=    Post    ${CREATE_TERMI_COLLECTION_API_POINT}/${prefix}    headers=${headers}    data=${json}
+    [Return]        ${response}

--- a/resources/selenium keywords/generic/generic selenium.robot
+++ b/resources/selenium keywords/generic/generic selenium.robot
@@ -34,6 +34,24 @@ Find and hide element
     ${elem}=  Get WebElement  ${element}
     Run keyword and ignore error  Hide element  ${elem}
 
+Clear input robustly
+    [Arguments]    ${element}
+    Wait Until Page Contains element  ${element}
+    Run Keyword And Ignore Error    Clear Element Text    ${element}
+    ${elem}=    Get WebElement    ${element}
+    ${id}=    Get Element Attribute    ${element}    id
+    Execute JavaScript
+    ...    var el = document.getElementById('${id}');
+    ...    const setter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(el), 'value')?.set;
+    ...    if (setter) {
+    ...        setter.call(el, '');
+    ...    } else {
+    ...        el.value = '';
+    ...    }
+    ...    el.dispatchEvent(new Event('input', { bubbles: true }));
+    ...    el.dispatchEvent(new Event('change', { bubbles: true }));
+    ...    ARGUMENTS    ${elem}
+
 Input text with wait
     [Arguments]  ${element}  ${text}  ${timeout}=${SELENIUM_DEFAULT_TIMEOUT}  ${tab}=True
     Wait Until Page Contains Element    ${element}    timeout=${timeout}

--- a/resources/selenium keywords/models/datamodel/datamodel associations.robot
+++ b/resources/selenium keywords/models/datamodel/datamodel associations.robot
@@ -45,7 +45,7 @@ ${Datamodel association search terminology all}                //li[@id="termino
 ${association prefix not set error}              Assosiaation yksilöivää tunnusta ei ole määritelty
 ${association prefix starts with number error}   Assosiaation tunnus ei voi alkaa numerolla
 ${association prefix size error}                 Assosiaation tunnuksen pituus ei täytä vaatimuksia (2-120 merkkiä)
-${association prefix valid character error}      Assosiaation tunnuksen sallitut merkit ovat a-z, 0-9, alaviiva ja väliviiva
+${association prefix valid character error}      Assosiaation tunnuksen sallitut merkit ovat a-z, A-Z, 0-9, alaviiva ja väliviiva.
 ${association name not set error}                Assosiaation nimeä ei ole määritelty
 
 *** Keywords ***

--- a/resources/selenium keywords/models/datamodel/datamodel associations.robot
+++ b/resources/selenium keywords/models/datamodel/datamodel associations.robot
@@ -44,7 +44,7 @@ ${Datamodel association search terminology all}                //li[@id="termino
 # Errors
 ${association prefix not set error}              Assosiaation yksilöivää tunnusta ei ole määritelty
 ${association prefix starts with number error}   Assosiaation tunnus ei voi alkaa numerolla
-${association prefix size error}                 Assosiaation tunnuksen pituus ei täytä vaatimuksia (2-32 merkkiä)
+${association prefix size error}                 Assosiaation tunnuksen pituus ei täytä vaatimuksia (2-120 merkkiä)
 ${association prefix valid character error}      Assosiaation tunnuksen sallitut merkit ovat a-z, 0-9, alaviiva ja väliviiva
 ${association name not set error}                Assosiaation nimeä ei ole määritelty
 

--- a/resources/selenium keywords/models/datamodel/datamodel attributes.robot
+++ b/resources/selenium keywords/models/datamodel/datamodel attributes.robot
@@ -54,7 +54,7 @@ ${Datamodel attribute search terminology all}                //li[@id="terminolo
 ${attribute prefix not set error}              Attribuutin yksilöivää tunnusta ei ole määritelty
 ${attribute prefix starts with number error}   Attribuutin tunnus ei voi alkaa numerolla
 ${attribute prefix size error}                 Attribuutin tunnuksen pituus ei täytä vaatimuksia (2-120 merkkiä)
-${attribute prefix valid character error}      Attribuutin tunnuksen sallitut merkit ovat a-z, 0-9, alaviiva ja väliviiva
+${attribute prefix valid character error}      Attribuutin tunnuksen sallitut merkit ovat a-z, A-Z, 0-9, alaviiva ja väliviiva.
 ${attribute name not set error}                Attribuutin nimeä ei ole määritelty
 
 *** Keywords ***

--- a/resources/selenium keywords/models/datamodel/datamodel attributes.robot
+++ b/resources/selenium keywords/models/datamodel/datamodel attributes.robot
@@ -53,7 +53,7 @@ ${Datamodel attribute search terminology all}                //li[@id="terminolo
 # Errors
 ${attribute prefix not set error}              Attribuutin yksilöivää tunnusta ei ole määritelty
 ${attribute prefix starts with number error}   Attribuutin tunnus ei voi alkaa numerolla
-${attribute prefix size error}                 Attribuutin tunnuksen pituus ei täytä vaatimuksia (2-32 merkkiä)
+${attribute prefix size error}                 Attribuutin tunnuksen pituus ei täytä vaatimuksia (2-120 merkkiä)
 ${attribute prefix valid character error}      Attribuutin tunnuksen sallitut merkit ovat a-z, 0-9, alaviiva ja väliviiva
 ${attribute name not set error}                Attribuutin nimeä ei ole määritelty
 

--- a/resources/selenium keywords/models/datamodel/datamodel classes.robot
+++ b/resources/selenium keywords/models/datamodel/datamodel classes.robot
@@ -46,7 +46,7 @@ ${Datamodel class search terminology all}                //li[@id="terminology-s
 # Errors
 ${Class prefix not set error}              Luokan tunnusta ei ole määritetty
 ${Class prefix starts with number error}   Luokan tunnus ei voi alkaa numerolla
-${Class prefix size error}                 Luokan tunnuksen pituus ei täytä vaatimuksia (2-32 merkkiä)
+${Class prefix size error}                 Luokan tunnuksen pituus ei täytä vaatimuksia (2-120 merkkiä)
 ${Class prefix valid character error}      Luokan tunnuksen sallitut merkit ovat a-z, 0-9, alaviiva ja väliviiva
 ${Class name not set error}                Luokan nimeä ei ole määritelty
 

--- a/resources/selenium keywords/models/datamodel/datamodel classes.robot
+++ b/resources/selenium keywords/models/datamodel/datamodel classes.robot
@@ -47,7 +47,7 @@ ${Datamodel class search terminology all}                //li[@id="terminology-s
 ${Class prefix not set error}              Luokan tunnusta ei ole määritetty
 ${Class prefix starts with number error}   Luokan tunnus ei voi alkaa numerolla
 ${Class prefix size error}                 Luokan tunnuksen pituus ei täytä vaatimuksia (2-120 merkkiä)
-${Class prefix valid character error}      Luokan tunnuksen sallitut merkit ovat a-z, 0-9, alaviiva ja väliviiva
+${Class prefix valid character error}      Luokan tunnuksen sallitut merkit ovat a-z, A-Z, 0-9, alaviiva ja väliviiva.
 ${Class name not set error}                Luokan nimeä ei ole määritelty
 
 *** Keywords ***

--- a/resources/selenium keywords/models/datamodel/datamodel create dialog.robot
+++ b/resources/selenium keywords/models/datamodel/datamodel create dialog.robot
@@ -58,13 +58,13 @@ Select create datamodel core model type
 Select create datamodel domain ${domain}
     Click element with wait  ${Datamodel domain select}
     Input text with wait     ${Datamodel domain select}    ${domain}  tab=False
-    Click element with wait  //li/mark[text()="${domain}"]
+    Click element with wait  //li[text()="${domain}"]
     Press Keys               None  TAB
 
 Select create datamodel contributor ${contributor}
     Click element with wait  ${Datamodel contributor select}
     Input text with wait     ${Datamodel contributor select}    ${contributor}  tab=False
-    Click element with wait  //li/mark[text()="${contributor}"]
+    Click element with wait  //li[text()="${contributor}"]
     Press Keys               None  TAB
 
 Select create datamodel language ${language}

--- a/resources/selenium keywords/models/datamodel/datamodel editing.robot
+++ b/resources/selenium keywords/models/datamodel/datamodel editing.robot
@@ -137,7 +137,7 @@ Add datamodel link to datamodel in links tab
     Input text with wait     ${Add terminology dialog search input}  ${datamodel}
     
     Wait Until Page Contains Element    //input[contains(@id, "select-multiple-checkbox")]
-    Click Element At Coordinates        //input[contains(@id, "select-multiple-checkbox")]    0    0
+    Click Element At Coordinates        //input[contains(@id, "select-multiple-checkbox")]    5   5
     Click element with wait  ${Datamodel links terminology links submit button}
     
 Remove link from link editing

--- a/resources/selenium keywords/models/datamodel/search page.robot
+++ b/resources/selenium keywords/models/datamodel/search page.robot
@@ -3,7 +3,7 @@ Library   String
 Library   SeleniumLibrary
 
 *** Variables ***
-${Datamodel search page header}                   //h1[text()="Tietomallit"]
+${Datamodel search page header}                   //h1[@id="page-title"]
 ${Search box datamodel}                           //input[@id="filter-keyword-input"]
 ${Reset all filters button}                       //button[@id="filter-reset-button"]
 

--- a/resources/selenium keywords/models/datamodel/search page.robot
+++ b/resources/selenium keywords/models/datamodel/search page.robot
@@ -35,7 +35,9 @@ Select datamodel ${datamodel}
     Click element with wait           //h2[@id="card-title-link"]/span[text()="${Datamodel}"]
 
 Search datamodel ${Datamodel}
+    Press Keys                        None  ESCAPE
     Input text with wait              ${Search box datamodel}  ${Datamodel}
+    Press Keys                        None  ESCAPE
     Click element with wait           ${Search box datamodel}
 
 Clear text search filter

--- a/resources/selenium keywords/models/datamodel/search page.robot
+++ b/resources/selenium keywords/models/datamodel/search page.robot
@@ -8,10 +8,10 @@ ${Search box datamodel}                           //input[@id="filter-keyword-in
 ${Reset all filters button}                       //button[@id="filter-reset-button"]
 
 ${Organization filter}                            //input[@id="filter-organization-selector"]
-${Organization filter item}                       //ul[@id="filter-organization-selector-popover"]/div/div
+${Organization filter item}                       //ul[@id="filter-organization-selector-popover"]
 ${Clear organization filter}                      ${Organization filter}/../../div/div/button
 ${Language filter}                                //input[@id="filter-language-selector"]
-${Language filter item}                           //ul[@id="filter-language-selector-popover"]/div/div
+${Language filter item}                           //ul[@id="filter-language-selector-popover"]
 ${Clear language filter}                          ${Language filter}/../../div/div/button
 
 ${Filter chips}                                   //*[@id="result-counts-chips"]/button
@@ -35,10 +35,8 @@ Select datamodel ${datamodel}
     Click element with wait           //h2[@id="card-title-link"]/span[text()="${Datamodel}"]
 
 Search datamodel ${Datamodel}
-    Press Keys                        None  ESCAPE
-    Input text with wait              ${Search box datamodel}  ${Datamodel}
-    Press Keys                        None  ESCAPE
-    Click element with wait           ${Search box datamodel}
+    Input text with wait              ${Search box datamodel}  ${Datamodel}  tab=False
+    Click element with wait           ${Datamodel search page header}
 
 Clear text search filter
     Click element with wait           ${Search box datamodel}/../*[2]

--- a/resources/selenium keywords/models/terminology/collection page.robot
+++ b/resources/selenium keywords/models/terminology/collection page.robot
@@ -18,7 +18,7 @@ ${Create collection button}                     //button[text()="Lisää uusi k�
 ${Add concept to collection button}             //button[text()="Lisää käsite käsitekokoelmaan"]  |  //button[text()="Add concept to collection"]
 ${Close and add concept to collection button}   //button[text()="Lisää käsite"]  |  //button[text()="Lisää käsitteet"]  |  //button[text()="Add concept"]  |  //button[text()="Add concepts"]
 
-${Collection empty name error}          Etuliitteen sallitut merkit ovat a-z, A-Z, 0-9, alaviiva ja väliviiva.
+${Collection empty name error}          Käsitekokoelman nimi tulee olla määritettynä vähintään yhdellä kielellä.
 
 *** Keywords ***
 Delete collection

--- a/resources/selenium keywords/models/terminology/collection page.robot
+++ b/resources/selenium keywords/models/terminology/collection page.robot
@@ -18,7 +18,7 @@ ${Create collection button}                     //button[text()="Lisää uusi k�
 ${Add concept to collection button}             //button[text()="Lisää käsite käsitekokoelmaan"]  |  //button[text()="Add concept to collection"]
 ${Close and add concept to collection button}   //button[text()="Lisää käsite"]  |  //button[text()="Lisää käsitteet"]  |  //button[text()="Add concept"]  |  //button[text()="Add concepts"]
 
-${Collection empty name error}          Etuliitteen sallitut merkit ovat a-z, 0-9, alaviiva ja väliviiva
+${Collection empty name error}          Etuliitteen sallitut merkit ovat a-z, A-Z, 0-9, alaviiva ja väliviiva.
 
 *** Keywords ***
 Delete collection

--- a/resources/selenium keywords/models/terminology/collection page.robot
+++ b/resources/selenium keywords/models/terminology/collection page.robot
@@ -80,13 +80,13 @@ Save collect creation
     END
 
 Remove concept ${concept name} from collection creation
-    Click element with wait  //span[text()="${concept name}"]
+    Click element with wait  //span[contains(., "${concept name}")]
 
 Add concept ${concept name} to collection
     Click element with wait  ${Add concept to collection button}
     Search concept ${concept_name} from add dialog
     Click element with wait  ${Search button from create dialog}
-    Click element with wait  //span/b[text()="${concept_name}"]
+    Click element with wait  //span[contains(., "${concept name}")]
     Click element with wait  ${Close and add concept to collection button}
 
 Verify new collection page is not open

--- a/resources/selenium keywords/models/terminology/collection page.robot
+++ b/resources/selenium keywords/models/terminology/collection page.robot
@@ -10,6 +10,7 @@ ${collection cancel button}                     //button[@id="cancel-button"]
 ${Edit collection button}                       //button[@id="edit-collection-button"]
 ${Collection create save button}                //button[text()="Tallenna"]  |  //button[text()="Save"]
 
+${Collection identifier input}                  //input[@id="prefix-input"]
 ${Collection name input}                        //input[@placeholder="Kirjoita nimi"]  |  //input[@placeholder="Enter a name"]
 ${Collection definition input}                  //textarea[@placeholder="Kirjoita kuvaus"]
 
@@ -17,7 +18,7 @@ ${Create collection button}                     //button[text()="Lisää uusi k�
 ${Add concept to collection button}             //button[text()="Lisää käsite käsitekokoelmaan"]  |  //button[text()="Add concept to collection"]
 ${Close and add concept to collection button}   //button[text()="Lisää käsite"]  |  //button[text()="Lisää käsitteet"]  |  //button[text()="Add concept"]  |  //button[text()="Add concepts"]
 
-${Collection empty name error}          Käsitekokoelman nimi tulee olla määritettynä vähintään yhdellä kielellä.
+${Collection empty name error}          Etuliitteen sallitut merkit ovat a-z, 0-9, alaviiva ja väliviiva
 
 *** Keywords ***
 Delete collection
@@ -57,6 +58,9 @@ Open create collection dialog
 Verify page does not contain create collection button
     Open terminology information
     Wait until page does not contain element    ${Create collection button}
+
+Give new collection identifier as ${identifier}
+    Input text with wait  ${Collection identifier input}  ${identifier}
 
 Name new collection as ${concept name}
     Input text with wait  ${collection name input}  ${concept name} 

--- a/resources/selenium keywords/models/terminology/concept page.robot
+++ b/resources/selenium keywords/models/terminology/concept page.robot
@@ -547,6 +547,7 @@ Add new term to new concept
     IF  '${Term language}' != '${NONE}'
         Click element with wait  ${new term langueage input}
         Click element with wait  //li[text()="${Term language}"]
+        Sleep  2s
     END
     IF  '${Term type}' != '${NONE}'
         Click element with wait  //label[text()="${Term type}"]

--- a/resources/selenium keywords/models/terminology/concept page.robot
+++ b/resources/selenium keywords/models/terminology/concept page.robot
@@ -92,8 +92,9 @@ ${Term extra info in term information title}      //h3[text()="Termin lisätieto
 ${Scope in term information title}                //h3[text()="Käyttöala"]
 ${Source in term information title}               //h3[text()="Lähde"]
 
-${Term information close button}                //button[text()="Sulje"]
 
+${Term information close button}                //button[text()="Sulje"]
+${Terminlogy copy success dialog close button}  //button[text()="Sulje"]
 ${Recommended term can't be changed error}      //div[text()="Suositettavan termin tyyppiä ei voi muuttaa, koska muita suositettavia termejä ei ole määritetty. Lisää uusi suositettava termi tai muuta olemassa oleva termi suositettavaksi termiksi."]
 
 ${Change term type button}              //button[text()="Muuta termin tyyppi"]
@@ -242,6 +243,10 @@ Create copy terminology dialog
     IF  '${Valid}' == '${True}'
         Wait Until Page does not Contain element    ${Copy create terminology button}  timeout=60
     END
+
+Close copy confirmation dialog
+    Wait until page contains element  ${Terminlogy copy success dialog close button}
+    Click element with wait  ${Terminlogy copy success dialog close button}
 
 Input manual prefix ${prefix} on copy dialog
     Click element with wait    ${Copy manual prefix input}                     

--- a/resources/selenium keywords/models/terminology/concept page.robot
+++ b/resources/selenium keywords/models/terminology/concept page.robot
@@ -301,7 +301,7 @@ Verify new concept page is not open
 Add concept ${concept_name} as relation
     Input text with wait     ${Concept relation search input}  ${concept_name}
     Click element with wait  ${Concept relation search button}
-    Click element with wait  //b[text()="${concept_name}"]
+    Click element with wait  //label/span[text()="${concept_name}"]
     Click element with wait  ${Close and add concept relation button} 
 
 Create concept 
@@ -387,10 +387,7 @@ Add information to concept
     END
     IF  '${subject}' != '${NONE}'
         IF  '${subject}' == 'CLEAR'
-            Click element with wait    ${concept subject input}
-                Press Keys                          ${search box terminology}    HOME
-                Press Keys                          ${search box terminology}    SHIFT+END
-                Press Keys                          ${search box terminology}    BACKSPACE
+           Clear input robustly   ${concept subject input}
         ELSE
             Input text with wait  ${concept subject input}  ${subject}
         END
@@ -398,10 +395,7 @@ Add information to concept
     IF  '${change history}' != '${NONE}'
         Click element with wait   ${concept organization box}  
         IF  '${change history}' == 'CLEAR'
-            Click element with wait    ${concept organization history change input}
-                Press Keys                          ${search box terminology}    HOME
-                Press Keys                          ${search box terminology}    SHIFT+END
-                Press Keys                          ${search box terminology}    BACKSPACE
+            Clear input robustly    ${concept organization history change input}
         ELSE
             Input text with wait      ${concept organization history change input}  ${change history}
         END
@@ -410,10 +404,7 @@ Add information to concept
     IF  '${etymology}' != '${NONE}'
         Click element with wait   ${concept organization box}  
         IF  '${etymology}' == 'CLEAR'
-            Click element with wait    ${concept organization etymology input}
-                Press Keys                          ${search box terminology}    HOME
-                Press Keys                          ${search box terminology}    SHIFT+END
-                Press Keys                          ${search box terminology}    BACKSPACE
+            Clear input robustly    ${concept organization etymology input}
         ELSE
             Input text with wait      ${concept organization etymology input}  ${etymology}
         END
@@ -459,10 +450,10 @@ Add information to concept
     IF  '${concept class}' != '${NONE}'
         Click element with wait  ${concept terms other information box}
         IF  '${concept class}' == 'CLEAR'
-            Click element with wait    ${concept organization concept class input}
-                Press Keys                          ${search box terminology}    HOME
-                Press Keys                          ${search box terminology}    SHIFT+END
-                Press Keys                          ${search box terminology}    BACKSPACE
+            Clear input robustly  ${concept organization concept class input}
+            # The refocus is needed for the value to update correctly for some reason
+            Press Keys    None      TAB
+            Click element with wait  ${concept organization concept class input}
         ELSE
             Input text with wait     ${concept organization concept class input}    ${concept class}
         END
@@ -727,19 +718,19 @@ Verify concept page contains all information
         Wait until page contains element  //div[text()="${subject}"]/div[text()="Aihealue"]
     END
     IF  '${change history}' != '${NONE}'
-        Wait until page contains element  //div[text()="${change history}"]/div[text()="Muutoshistoriatiedot"]
+        Wait until page contains element  //div[text()="Muutoshistoriatiedot"]/following-sibling::span[text()="${change history}"]
     END
     IF  '${etymology}' != '${NONE}'
-        Wait until page contains element  //div[text()="${etymology}"]/div[text()="Käytön historiatieto (etymologia)"]
+        Wait until page contains element  //div[text()="Käytön historiatieto (etymologia)"]/following-sibling::span[text()="${etymology}"]
     END
     IF  '${Note}' != '${NONE}'
-        Wait until page contains element  //div/ul/li[text()="${Note}"]/../../div[text()="Ylläpitäjän muistiinpano"]
+        Wait until page contains element  //span[text()="${Note}"]
     END
     IF  '${sources}' != '${NONE}'
         Wait until page contains element  //div/ul/li[text()="${sources}"]/../../div[text()="Lähteet"]
     END
     IF  '${concept class}' != '${NONE}'
-        Wait until page contains element  //div[text()="${concept class}"]/div[text()="Käsitteen luokka"]
+        Wait until page contains element  //*[text()="${concept class}"]
     END
     IF  '${broader concept}' != '${NONE}'
         Wait until page contains element  //a[text()="${broader concept}"]
@@ -798,10 +789,10 @@ Verify concept page does not contain all information
         Wait until page does not contain element  //div[text()="${subject}"]/div[text()="Aihealue"]
     END
     IF  '${change history}' != '${NONE}'
-        Wait until page does not contain element  //div[text()="${change history}"]/div[text()="Muutoshistoriatiedot"]
+        Wait until page does not contain element  //div[text()="Muutoshistoriatiedot"]/following-sibling::span[text()="${change history}"]
     END
     IF  '${etymology}' != '${NONE}'
-        Wait until page does not contain element  //div[text()="${etymology}"]/div[text()="Käytön historiatieto (etymologia)"]
+        Wait until page does not contain element  //div[text()="Käytön historiatieto (etymologia)"]/following-sibling::span[text()="${etymology}"]
     END
     IF  '${Note}' != '${NONE}'
         Wait until page does not contain element  //div/ul/li[text()="${Note}"]/../../div[text()="Ylläpitäjän muistiinpano"]
@@ -810,7 +801,7 @@ Verify concept page does not contain all information
         Wait until page does not contain element  //div/ul/li[text()="${sources}"]/../../div[text()="Lähteet"]
     END
     IF  '${concept class}' != '${NONE}'
-        Wait until page does not contain element  //div[text()="${concept class}"]/div[text()="Käsitteen luokka"]
+        Wait until page does not contain element  //*[text()="${concept class}"]
     END
     IF  '${broader concept}' != '${NONE}'
         Wait until page does not contain element  //a[text()="${broader concept}"]

--- a/resources/selenium keywords/models/terminology/concept page.robot
+++ b/resources/selenium keywords/models/terminology/concept page.robot
@@ -244,7 +244,7 @@ Create copy terminology dialog
     END
 
 Input manual prefix ${prefix} on copy dialog
-    Click element with wait    ${Copy manual prefix select}                     
+    Click element with wait    ${Copy manual prefix input}                     
     Input text with Wait       ${Copy manual prefix input}    ${prefix}       
 
 Verify page does not contain copy terminology button

--- a/resources/selenium keywords/models/terminology/concept page.robot
+++ b/resources/selenium keywords/models/terminology/concept page.robot
@@ -152,7 +152,7 @@ ${Change recommended term Term family}        //input[@placeholder="Valitse term
 ${Change recommended term Term conjugation}   //input[@placeholder="Valitse termin luku"]
 ${Change recommended term Term word class}    //input[@placeholder="Valitse termin sanaluokka"]
 
-${Copy terminology invalid prefix error}      Etuliitteen sallitut merkit ovat a-z, 0-9, alaviiva ja väliviiva
+${Copy terminology invalid prefix error}      Etuliitteen sallitut merkit ovat a-z, A-Z, 0-9, alaviiva ja väliviiva.
 ${Copy terminology empty prefix error}        Tunnusta ei ole määritelty
 ${Copy terminology in use prefix error}       Tunnus on käytössä
 
@@ -388,7 +388,9 @@ Add information to concept
     IF  '${subject}' != '${NONE}'
         IF  '${subject}' == 'CLEAR'
             Click element with wait    ${concept subject input}
-            Press Keys    None         CTRL+a+BACKSPACE
+                Press Keys                          ${search box terminology}    HOME
+                Press Keys                          ${search box terminology}    SHIFT+END
+                Press Keys                          ${search box terminology}    BACKSPACE
         ELSE
             Input text with wait  ${concept subject input}  ${subject}
         END
@@ -397,7 +399,9 @@ Add information to concept
         Click element with wait   ${concept organization box}  
         IF  '${change history}' == 'CLEAR'
             Click element with wait    ${concept organization history change input}
-            Press Keys    None         CTRL+a+BACKSPACE
+                Press Keys                          ${search box terminology}    HOME
+                Press Keys                          ${search box terminology}    SHIFT+END
+                Press Keys                          ${search box terminology}    BACKSPACE
         ELSE
             Input text with wait      ${concept organization history change input}  ${change history}
         END
@@ -407,7 +411,9 @@ Add information to concept
         Click element with wait   ${concept organization box}  
         IF  '${etymology}' == 'CLEAR'
             Click element with wait    ${concept organization etymology input}
-            Press Keys    None         CTRL+a+BACKSPACE
+                Press Keys                          ${search box terminology}    HOME
+                Press Keys                          ${search box terminology}    SHIFT+END
+                Press Keys                          ${search box terminology}    BACKSPACE
         ELSE
             Input text with wait      ${concept organization etymology input}  ${etymology}
         END
@@ -454,7 +460,9 @@ Add information to concept
         Click element with wait  ${concept terms other information box}
         IF  '${concept class}' == 'CLEAR'
             Click element with wait    ${concept organization concept class input}
-            Press Keys    None         CTRL+a+BACKSPACE
+                Press Keys                          ${search box terminology}    HOME
+                Press Keys                          ${search box terminology}    SHIFT+END
+                Press Keys                          ${search box terminology}    BACKSPACE
         ELSE
             Input text with wait     ${concept organization concept class input}    ${concept class}
         END

--- a/resources/selenium keywords/models/terminology/search page.robot
+++ b/resources/selenium keywords/models/terminology/search page.robot
@@ -70,7 +70,7 @@ Clear terminology search
     
 Search and select terminology ${Terminology}
     Search terminology ${Terminology}
-    Click element with wait           //h2/span/b[contains(text(), "${Terminology}")]
+    Click element with wait           //h2[contains(., "${Terminology}")]
     Verify page is terminology page
 
 Get status count from ${filter} filter

--- a/resources/selenium keywords/models/terminology/search page.robot
+++ b/resources/selenium keywords/models/terminology/search page.robot
@@ -71,10 +71,7 @@ Search terminology ${Terminology}
     Click element with wait             ${Terminology search page header}
 
 Clear terminology search
-    Click element with wait             ${search box terminology}
-    Press Keys                          ${search box terminology}    HOME
-    Press Keys                          ${search box terminology}    SHIFT+END
-    Press Keys                          ${search box terminology}    BACKSPACE
+    Clear input robustly               ${search box terminology}
     
 Search and select terminology ${Terminology}
     Search terminology ${Terminology}

--- a/resources/selenium keywords/models/terminology/search page.robot
+++ b/resources/selenium keywords/models/terminology/search page.robot
@@ -61,12 +61,20 @@ Select organization ${organization}
     Click element with wait           //li[text()="${organization}"]
     
 Search terminology ${Terminology}
-    Input text with wait              ${search box terminology}  ${Terminology}
-    Press Keys                        None      ENTER
+    Wait Until Page Contains Element    ${search box terminology}
+    Wait Until Element Is Visible       ${search box terminology}
+    Wait Until Element Is Enabled       ${search box terminology}
+    Click element with wait             ${search box terminology}
+    Press Keys                          ${search box terminology}    HOME
+    Press Keys                          ${search box terminology}    SHIFT+END
+    Press Keys                          ${search box terminology}    ${Terminology}
+    Click element with wait             ${Terminology search page header}
 
 Clear terminology search
-    Double click element            ${search box terminology}
-    press keys                      ${search box terminology}           CTRL+a+BACKSPACE
+    Click element with wait             ${search box terminology}
+    Press Keys                          ${search box terminology}    HOME
+    Press Keys                          ${search box terminology}    SHIFT+END
+    Press Keys                          ${search box terminology}    BACKSPACE
     
 Search and select terminology ${Terminology}
     Search terminology ${Terminology}

--- a/resources/selenium keywords/models/terminology/terminology create dialog.robot
+++ b/resources/selenium keywords/models/terminology/terminology create dialog.robot
@@ -15,7 +15,6 @@ ${Terminology select organization input}      ${Create terminology dialog}//inpu
 ${Terminology select domain input}      ${Create terminology dialog}//input[@placeholder="Valitse sanaston tietoalueet"]
 ${Alert on create terminology}          ${Create terminology dialog}//section[@role="alert"]//div[text()="Puuttuvia tietoja"]
 ${Terminology create email input}      ${Create terminology dialog}//input[@placeholder="Esim. yllapito@example.org"]
-${Select own prefix}                   ${Create terminology dialog}//label[text()="Valitse oma tunnus"]
 ${Prefix input}                        ${Create terminology dialog}//input[@id="prefix-text-input"]
 
 ${Concept language finnish}  suomi FI
@@ -55,7 +54,6 @@ Create terminology from dialog
         Press Keys               None  TAB
     END
     IF  '${prefix}' != '${NONE}'
-        Click element with wait  ${Select own prefix}
         Input text with wait  ${Prefix input}  ${prefix}
     END
     IF  '${email}' != '${NONE}'

--- a/resources/selenium keywords/models/terminology/terminology page.robot
+++ b/resources/selenium keywords/models/terminology/terminology page.robot
@@ -4,13 +4,13 @@ ${Terminology download button}      //button[@id="export-terminology-button"]
 ${Terminology modify button}        //button[@id="edit-terminology-button"]
 ${Create terminology button}        //button[text()="Lisää uusi sanasto"]  |  //button[text()="Add new terminology"]
 
-${Displayed terminology name fi}    //div[@id="preferred-label"]/ul/li[@lang="fi"]/span
-${Displayed terminology name en}    //div[@id="preferred-label"]/ul/li[@lang="en"]/span
-${Displayed terminology name sv}    //div[@id="preferred-label"]/ul/li[@lang="sv"]/span
+${Displayed terminology name fi}    //div/ul/li[@lang="fi"]
+${Displayed terminology name en}    //div/ul/li[@lang="en"]
+${Displayed terminology name sv}    //div/ul/li[@lang="sv"]
 
-${Displayed terminology description fi}    //div[@id="description"]/ul/li[@lang="fi"]/span
-${Displayed terminology description en}    //div[@id="description"]/ul/li[@lang="en"]/span
-${Displayed terminology description sv}    //div[@id="description"]/ul/li[@lang="sv"]/span
+${Displayed terminology description fi}    //div/ul/li[@lang="fi"]
+${Displayed terminology description en}    //div/ul/li[@lang="en"]
+${Displayed terminology description sv}    //div/ul/li[@lang="sv"]
 
 ${Displayed terminology status}          //span[@id="status-chip"]/span
 ${Displayed terminology domains}         //div[@id="information-domains"]
@@ -203,10 +203,13 @@ Select prefix automatic on modify terminology
     Click element with wait  ${Terminology modify prefix input automatic} 
 
 Select prefix manual on modify terminology
-    Click element with wait  ${Terminology modify prefix input manual}
+    Click element with wait  ${Terminology modify prefix input}
 
 Input prefix ${prefix} on modify terminology
     Input text with wait    ${Terminology modify prefix input}   ${prefix}
+
+Clear prefix input on modify terminology
+    Clear input robustly  ${Terminology modify prefix input}
     
 Input contact ${contact} on modify terminology
     Input text with wait    ${Terminology modify contact input}   ${contact}

--- a/resources/variables/dev/urls.robot
+++ b/resources/variables/dev/urls.robot
@@ -1,3 +1,3 @@
 *** Variables ***
 ${TERMINOLOGIES_URL}   https://sanastot.dev.yti.cloud.dvv.fi/
-${DATAMODELS_URL}      https://tietomallit-v2.dev.yti.cloud.dvv.fi/
+${DATAMODELS_URL}      https://tietomallit.dev.yti.cloud.dvv.fi/

--- a/resources/variables/run variables.robot
+++ b/resources/variables/run variables.robot
@@ -12,6 +12,7 @@ ${API_KEY}                      ${EMPTY}
 ${DEFAULT TERMINOLOGY NAME}         Auto_t
 ${DEFAULT CONCEPT NAME}             Auto_Concept
 ${DEFAULT COLLECTION NAME}          Auto_Collection
+${DEFAULT COLLECTION PREFIX}        auto_col
 ${DEFAULT TERMINOLOGY PREFIX}       auto_pre
 
 ${DEFAULT DATAMODEL NAME}           auto
@@ -62,6 +63,7 @@ Set default terminology variables
     Set Test Variable    ${DEFAULT TERMINOLOGY PREFIX}  ${DEFAULT TERMINOLOGY PREFIX}_${test_case_id.lower()}
     Set Test Variable    ${DEFAULT CONCEPT NAME}        ${DEFAULT CONCEPT NAME}_${test_case_id}
     Set Test Variable    ${DEFAULT COLLECTION NAME}     ${DEFAULT COLLECTION NAME}_${test_case_id}
+    Set Test Variable    ${DEFAULT COLLECTION PREFIX}   ${DEFAULT COLLECTION PREFIX}_${test_case_id.lower()}
 
 Set default datamodel variables
     [Arguments]          ${test_case_id}

--- a/tests/datamodel/datamodel_create_and_edit_associations.robot
+++ b/tests/datamodel/datamodel_create_and_edit_associations.robot
@@ -126,9 +126,8 @@ T5C4. Create valid association with all options
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
     
     @{terminologies}=  Create list  
     ...  http://uri.suomi.fi/terminology/${DEFAULT TERMINOLOGY PREFIX}
@@ -320,8 +319,9 @@ T5C7. Verify invalid association modify errors
     Edit association
     
     Click element with wait          ${Datamodel ASSOCIATION label input fi}
-    Press Keys                       None  CTRL+A
-    Press Keys                       None  BACKSPACE
+    Press Keys                          None   HOME
+    Press Keys                          None   SHIFT+END
+    Press Keys                          None   BACKSPACE
     Save association
     Verify create datamodel association contains error ${ASSOCIATION name not set error}
 
@@ -348,9 +348,8 @@ T5C8. Modify association
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
     
     @{terminologies}=  Create list  
     ...  http://uri.suomi.fi/terminology/${DEFAULT TERMINOLOGY PREFIX}
@@ -439,9 +438,8 @@ T5C9. Modify association remove unnesecary
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
     
     @{terminologies}=  Create list  
     ...  http://uri.suomi.fi/terminology/${DEFAULT TERMINOLOGY PREFIX}
@@ -494,11 +492,13 @@ T5C9. Modify association remove unnesecary
     Edit association
     Input finnish association label             ${DEFAULT DATAMODEL ASSOCIATION NAME}
     Click element with wait                     ${Datamodel association label input sv}
-    Press Keys                                  None  CTRL+A
-    Press Keys                                  None  BACKSPACE
+    Press Keys                                  None   HOME
+    Press Keys                                  None   SHIFT+END
+    Press Keys                                  None   BACKSPACE
     Click element with wait                     ${Datamodel association label input en}
-    Press Keys                                  None  CTRL+A
-    Press Keys                                  None  BACKSPACE
+    Press Keys                                  None   HOME
+    Press Keys                                  None   SHIFT+END
+    Press Keys                                  None   BACKSPACE
 
     Remove upper association from association
     Remove corresponding association from association

--- a/tests/datamodel/datamodel_create_and_edit_attribute.robot
+++ b/tests/datamodel/datamodel_create_and_edit_attribute.robot
@@ -130,9 +130,8 @@ T4C4. Create valid attribute with all options
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
     
     @{terminologies}=  Create list  
     ...  http://uri.suomi.fi/terminology/${DEFAULT TERMINOLOGY PREFIX}
@@ -326,8 +325,9 @@ T4C7. Verify invalid attribute modify errors
     Edit attribute
     
     Click element with wait          ${Datamodel attribute label input fi}
-    Press Keys                       None  CTRL+A
-    Press Keys                       None  BACKSPACE
+    Press Keys                       None   HOME
+    Press Keys                       None   SHIFT+END
+    Press Keys                       None   BACKSPACE
     Save attribute
     Verify create datamodel attribute contains error ${attribute name not set error}
 
@@ -354,9 +354,8 @@ T4C8. Modify attribute
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
     
     @{terminologies}=  Create list  
     ...  http://uri.suomi.fi/terminology/${DEFAULT TERMINOLOGY PREFIX}
@@ -448,9 +447,8 @@ T4C9. Modify attribute remove unnesecary
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
     
     @{terminologies}=  Create list  
     ...  http://uri.suomi.fi/terminology/${DEFAULT TERMINOLOGY PREFIX}
@@ -503,11 +501,13 @@ T4C9. Modify attribute remove unnesecary
     Edit attribute
     Input finnish attribute label               ${DEFAULT DATAMODEL ATTRIBUTE NAME}
     Click element with wait                     ${Datamodel attribute label input sv}
-    Press Keys                                  None  CTRL+A
-    Press Keys                                  None  BACKSPACE
+    Press Keys                                  None   HOME
+    Press Keys                                  None   SHIFT+END
+    Press Keys                                  None   BACKSPACE
     Click element with wait                     ${Datamodel attribute label input en}
-    Press Keys                                  None  CTRL+A
-    Press Keys                                  None  BACKSPACE
+    Press Keys                                  None   HOME
+    Press Keys                                  None   SHIFT+END
+    Press Keys                                  None   BACKSPACE
 
     Remove upper attribute from attribute
     Remove corresponding attribute from attribute

--- a/tests/datamodel/datamodel_create_and_edit_class.robot
+++ b/tests/datamodel/datamodel_create_and_edit_class.robot
@@ -128,9 +128,8 @@ T3C4. Create valid class with all options
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
     
     @{terminologies}=  Create list  
     ...  http://uri.suomi.fi/terminology/${DEFAULT TERMINOLOGY PREFIX}
@@ -352,9 +351,8 @@ T3C8. Modify class
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
     
     @{terminologies}=  Create list  
     ...  http://uri.suomi.fi/terminology/${DEFAULT TERMINOLOGY PREFIX}
@@ -452,9 +450,8 @@ T3C9. Modify class remove unnesecary
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
     
     @{terminologies}=  Create list  
     ...  http://uri.suomi.fi/terminology/${DEFAULT TERMINOLOGY PREFIX}
@@ -514,11 +511,13 @@ T3C9. Modify class remove unnesecary
     Remove disjoint class from class
     Input finnish class label                   ${DEFAULT DATAMODEL CLASS NAME}
     Click element with wait                     ${Datamodel class label input sv}
-    Press Keys                                  None  CTRL+A
-    Press Keys                                  None  BACKSPACE
+    Press Keys                                  None   HOME
+    Press Keys                                  None   SHIFT+END
+    Press Keys                                  None   BACKSPACE
     Click element with wait                     ${Datamodel class label input en}
-    Press Keys                                  None  CTRL+A
-    Press Keys                                  None  BACKSPACE
+    Press Keys                                  None   HOME
+    Press Keys                                  None   SHIFT+END
+    Press Keys                                  None   BACKSPACE
 
     Input finnish description into class        ${SPACE}
     Input swedish description into class        ${SPACE}

--- a/tests/datamodel/datamodel_create_and_edit_datamodel.robot
+++ b/tests/datamodel/datamodel_create_and_edit_datamodel.robot
@@ -476,6 +476,8 @@ T2C8. Add terminology and datamodel links to datamodel
     Reload page
     Select links tab
     Edit links from links tab
+    Remove link from link editing
+    Remove link from link editing
     Add terminology link to datamodel in links tab  ${DEFAULT TERMINOLOGY NAME}_1
     Remove link from link editing
     Save editing links 
@@ -486,7 +488,6 @@ T2C8. Add terminology and datamodel links to datamodel
     Save editing links 
 
     Edit links from links tab
-    Remove link from link editing
     Remove link from link editing
     Save editing links 
 

--- a/tests/terminology/terminology_copy_terminology.robot
+++ b/tests/terminology/terminology_copy_terminology.robot
@@ -23,7 +23,7 @@ T10C1. Verify copy button permissions
 
     [Teardown]  Teardown test Case delete terminology ${DEFAULT TERMINOLOGY NAME}
 
-T10C2. Create valid copy with automatically generated prefix
+T10C2. Create valid copy with own prefix
     Create terminology with api     ${DEFAULT TERMINOLOGY NAME}
     ...                             ${DRAFT}
     ...                             ${DOMAIN HOUSING}
@@ -47,11 +47,10 @@ T10C2. Create valid copy with automatically generated prefix
     Search and select terminology ${DEFAULT TERMINOLOGY NAME}
 
     Open copy terminology dialog
+    Input manual prefix ${DEFAULT TERMINOLOGY PREFIX}_copy on copy dialog
     Create copy terminology dialog
-    
-    # TODO bug where concept is not shown before refreshing page
-    Sleep  2
-    Reload page
+    Close copy confirmation dialog
+
 
     Verify displayed finish name is ${DEFAULT TERMINOLOGY NAME} (Copy)
     Verify displayed status is Luonnos
@@ -68,55 +67,7 @@ T10C2. Create valid copy with automatically generated prefix
     ...         Delete terminology ${DEFAULT TERMINOLOGY NAME} with api    AND
     ...         Delete terminology ${DEFAULT TERMINOLOGY NAME} (Copy) with api
 
-T10C3. Create valid copy with own prefix
-    Create terminology with api     ${DEFAULT TERMINOLOGY NAME}
-    ...                             ${DRAFT}
-    ...                             ${DOMAIN HOUSING}
-    ...                             ${ORGANIZATION AUTOMATION}
-    ...                             ${DEFAULT TERMINOLOGY PREFIX}
-
-    Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
-    ...                                  ${DEFAULT CONCEPT NAME}
-    ...                                  concept-1
-    ...                                  ${DRAFT}
-
-    ${members}=    Create List              concept-1
-    Create terminology collection with api  ${DEFAULT TERMINOLOGY NAME}
-    ...                                     ${DEFAULT COLLECTION NAME}
-    ...                                     ${COLLECTION ID DEFAULT}
-    ...                                     ${members}
-
-    Open terminology search page
-
-    Login with admin
-    Search and select terminology ${DEFAULT TERMINOLOGY NAME}
-
-    Open copy terminology dialog
-    Input manual prefix new_${DEFAULT TERMINOLOGY PREFIX} on copy dialog
-    
-    Create copy terminology dialog
-
-    # TODO bug where concept is not shown before refreshing page
-    Sleep  2
-    Reload page
-
-    Verify displayed finish name is ${DEFAULT TERMINOLOGY NAME} (Copy)
-    Verify displayed status is Luonnos
-    Verify displayed domains are Asuminen
-    Verify displayed organizations are Automaatiotestaus
-    Verify displayed languages are suomi FI
-    Verify displayed type is Terminologinen sanasto
-    Verify displayed url contains new_${DEFAULT TERMINOLOGY PREFIX}
-
-    Verify concept ${DEFAULT CONCEPT NAME} on terminology ${DEFAULT TERMINOLOGY NAME} (Copy)
-    Verify collection ${DEFAULT COLLECTION NAME} containing concept ${DEFAULT CONCEPT NAME} on terminology ${DEFAULT TERMINOLOGY NAME} (Copy)
-
-    [Teardown]  Run Keywords
-    ...         Teardown test Case    AND
-    ...         Delete terminology ${DEFAULT TERMINOLOGY NAME} with api    AND
-    ...         Delete terminology ${DEFAULT TERMINOLOGY NAME} (Copy) with api
-
-T10C4. Verify copy dialog errors    
+T10C3. Verify copy dialog errors    
     Create terminology with api     ${DEFAULT TERMINOLOGY NAME}
     ...                             ${DRAFT}
     ...                             ${DOMAIN HOUSING}

--- a/tests/terminology/terminology_copy_terminology.robot
+++ b/tests/terminology/terminology_copy_terminology.robot
@@ -63,7 +63,10 @@ T10C2. Create valid copy with automatically generated prefix
     Verify concept ${DEFAULT CONCEPT NAME} on terminology ${DEFAULT TERMINOLOGY NAME} (Copy)
     Verify collection ${DEFAULT COLLECTION NAME} containing concept ${DEFAULT CONCEPT NAME} on terminology ${DEFAULT TERMINOLOGY NAME} (Copy)
 
-    [Teardown]  Teardown test Case delete terminology ${DEFAULT TERMINOLOGY NAME}
+    [Teardown]  Run Keywords
+    ...         Teardown test Case    AND
+    ...         Delete terminology ${DEFAULT TERMINOLOGY NAME} with api    AND
+    ...         Delete terminology ${DEFAULT TERMINOLOGY NAME} (Copy) with api
 
 T10C3. Create valid copy with own prefix
     Create terminology with api     ${DEFAULT TERMINOLOGY NAME}
@@ -108,7 +111,10 @@ T10C3. Create valid copy with own prefix
     Verify concept ${DEFAULT CONCEPT NAME} on terminology ${DEFAULT TERMINOLOGY NAME} (Copy)
     Verify collection ${DEFAULT COLLECTION NAME} containing concept ${DEFAULT CONCEPT NAME} on terminology ${DEFAULT TERMINOLOGY NAME} (Copy)
 
-    [Teardown]  Teardown test Case delete terminology ${DEFAULT TERMINOLOGY NAME}
+    [Teardown]  Run Keywords
+    ...         Teardown test Case    AND
+    ...         Delete terminology ${DEFAULT TERMINOLOGY NAME} with api    AND
+    ...         Delete terminology ${DEFAULT TERMINOLOGY NAME} (Copy) with api
 
 T10C4. Verify copy dialog errors    
     Create terminology with api     ${DEFAULT TERMINOLOGY NAME}
@@ -138,4 +144,7 @@ T10C4. Verify copy dialog errors
     Input manual prefix new_${DEFAULT TERMINOLOGY PREFIX} on copy dialog
     Create copy terminology dialog
 
-    [Teardown]  Teardown test Case delete terminology ${DEFAULT TERMINOLOGY NAME}
+    [Teardown]  Run Keywords
+    ...         Teardown test Case    AND
+    ...         Delete terminology ${DEFAULT TERMINOLOGY NAME} with api    AND
+    ...         Delete terminology ${DEFAULT TERMINOLOGY NAME} (Copy) with api

--- a/tests/terminology/terminology_copy_terminology.robot
+++ b/tests/terminology/terminology_copy_terminology.robot
@@ -32,11 +32,10 @@ T10C2. Create valid copy with automatically generated prefix
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
 
-    ${members}=    Create List              04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ${members}=    Create List              concept-1
     Create terminology collection with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                     ${DEFAULT COLLECTION NAME}
     ...                                     ${COLLECTION ID DEFAULT}
@@ -75,11 +74,10 @@ T10C3. Create valid copy with own prefix
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
 
-    ${members}=    Create List              04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ${members}=    Create List              concept-1
     Create terminology collection with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                     ${DEFAULT COLLECTION NAME}
     ...                                     ${COLLECTION ID DEFAULT}

--- a/tests/terminology/terminology_create_collection.robot
+++ b/tests/terminology/terminology_create_collection.robot
@@ -69,21 +69,18 @@ T5C3. Create valid collection with multiple concepts
     
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}_1
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}_2
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce2
+    ...                                  concept-2
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e82
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}_3
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce3
+    ...                                  concept-3
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e83
 
     Open terminology search page
     Login with Admin

--- a/tests/terminology/terminology_create_collection.robot
+++ b/tests/terminology/terminology_create_collection.robot
@@ -32,6 +32,8 @@ T5C1. Verify create collection button permissions
     [Teardown]  Teardown test Case delete terminology ${DEFAULT TERMINOLOGY NAME}
 
 T5C2. Verify collection creation error messages
+    # TODO: remove skip after fixing the underlying issue (YTI-4387)
+    Skip 
     Create terminology with api     ${DEFAULT TERMINOLOGY NAME}
     ...                             ${VALID}
     ...                             ${DOMAIN HOUSING}

--- a/tests/terminology/terminology_create_collection.robot
+++ b/tests/terminology/terminology_create_collection.robot
@@ -53,6 +53,7 @@ T5C2. Verify collection creation error messages
     ...  Valid=${False}
     Verify error message ${Collection empty name error}
 
+    Give new collection identifier as ${DEFAULT COLLECTION PREFIX}
     Name new collection as ${DEFAULT COLLECTION NAME}
     Give new collection definition as definition
     Save collect creation
@@ -89,6 +90,7 @@ T5C3. Create valid collection with multiple concepts
     Search and select terminology ${DEFAULT TERMINOLOGY NAME}
 
     Open create collection dialog
+    Give new collection identifier as ${DEFAULT COLLECTION PREFIX}
     Name new collection as ${DEFAULT COLLECTION NAME}
     Give new collection definition as definition
     Add concept ${DEFAULT CONCEPT NAME}_1 to collection

--- a/tests/terminology/terminology_create_concept.robot
+++ b/tests/terminology/terminology_create_concept.robot
@@ -92,9 +92,8 @@ T4C3. Create valid concept with all information and relations
     
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}_2
     ...                                  ${DEFAULT CONCEPT NAME}_3
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce3
+    ...                                  concept-3
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e83
 
     ${definition}      Set Variable    definition
     ${example}         Set Variable    example

--- a/tests/terminology/terminology_create_concept_with_excel.robot
+++ b/tests/terminology/terminology_create_concept_with_excel.robot
@@ -33,6 +33,7 @@ T11C1. Verify creat concept with excel button permissions
     [Teardown]  Teardown test Case delete terminology ${DEFAULT TERMINOLOGY NAME}
 
 T11C2. Create valid concepts with excel file
+    Skip
     Create terminology with api     ${DEFAULT TERMINOLOGY NAME}
     ...                             ${VALID}
     ...                             ${DOMAIN HOUSING}
@@ -68,6 +69,7 @@ T11C2. Create valid concepts with excel file
     [Teardown]  Teardown test Case delete terminology ${DEFAULT TERMINOLOGY NAME}
 
 T11C3. Verify invalid excel files
+    Skip
     Create terminology with api     ${DEFAULT TERMINOLOGY NAME}
     ...                             ${VALID}
     ...                             ${DOMAIN HOUSING}

--- a/tests/terminology/terminology_create_terminology_with_form.robot
+++ b/tests/terminology/terminology_create_terminology_with_form.robot
@@ -98,7 +98,7 @@ T3C3. Create valid terminology from dialog
     ...  description=${NONE}
     ...  organization=${DEFAULT ORGANIZATION}
     ...  domain=${DEFAULT DOMAIN}
-    ...  prefix=${NONE}
+    ...  prefix=${DEFAULT TERMINOLOGY PREFIX}
     ...  email=${NONE}
     Verify dialog is not open
 

--- a/tests/terminology/terminology_modify_collection.robot
+++ b/tests/terminology/terminology_modify_collection.robot
@@ -53,25 +53,22 @@ T9C2. Modify collection
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}_1
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}_2
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce2
+    ...                                  concept-2
     ...                                  ${VALID}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e82
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}_3
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce3
+    ...                                  concept-3
     ...                                  ${VALID}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e83
 
     ${members}=    Create List              
-    ...    04bb2206-ba9e-4007-920d-f57ed0d4bce1       
-    ...    04bb2206-ba9e-4007-920d-f57ed0d4bce2
+    ...    concept-1       
+    ...    concept-2
     
     Create terminology collection with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                     ${DEFAULT COLLECTION NAME}

--- a/tests/terminology/terminology_modify_concept.robot
+++ b/tests/terminology/terminology_modify_concept.robot
@@ -16,9 +16,8 @@ T8C1. Verify concept modify button permissions
  
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
 
     Open terminology search page
     Search and select terminology ${DEFAULT TERMINOLOGY NAME}
@@ -49,21 +48,18 @@ T8C2. Modify concept
  
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}_1
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}_2
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce2
+    ...                                  concept-2
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e82
   
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}_4
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce4
+    ...                                  concept-4
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e84
     
     Create terminology with api     ${DEFAULT TERMINOLOGY NAME}_2
     ...                             ${VALID}
@@ -73,15 +69,13 @@ T8C2. Modify concept
     
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}_2
     ...                                  ${DEFAULT CONCEPT NAME}_3
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce3
+    ...                                  concept-3
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e83
    
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}_2
     ...                                  ${DEFAULT CONCEPT NAME}_5
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce5
+    ...                                  concept-5
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e85
 
     Open terminology search page
     Login with Admin
@@ -233,9 +227,8 @@ T8C3. Modify terms
  
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
 
     Open terminology search page
     Login with Admin
@@ -356,9 +349,8 @@ T8C4. Verify modify concept errors
  
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
 
     Open terminology search page
     Login with Admin
@@ -408,9 +400,8 @@ T8C5. Verify modify term errors
  
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
 
     Open terminology search page
     Login with Admin

--- a/tests/terminology/terminology_modify_concept.robot
+++ b/tests/terminology/terminology_modify_concept.robot
@@ -219,6 +219,8 @@ T8C2. Modify concept
     ...         Delete terminology ${DEFAULT TERMINOLOGY NAME}_2 with api
 
 T8C3. Modify terms
+    # TODO: unskip after bug related to content language is found
+    Skip
     Create terminology with api     ${DEFAULT TERMINOLOGY NAME}
     ...                             ${VALID}
     ...                             ${DOMAIN HOUSING}

--- a/tests/terminology/terminology_modify_concept.robot
+++ b/tests/terminology/terminology_modify_concept.robot
@@ -219,7 +219,7 @@ T8C2. Modify concept
     ...         Delete terminology ${DEFAULT TERMINOLOGY NAME}_2 with api
 
 T8C3. Modify terms
-    # TODO: unskip after bug related to content language is found
+    # TODO: unskip after bug related to content language is found (YTI-4389)
     Skip
     Create terminology with api     ${DEFAULT TERMINOLOGY NAME}
     ...                             ${VALID}

--- a/tests/terminology/terminology_modify_terminology.robot
+++ b/tests/terminology/terminology_modify_terminology.robot
@@ -79,7 +79,7 @@ T7C2. Modify terminology
     Select domain Demokratia on modify terminology
 
     Select type other on modify terminology
-    Select prefix manual on modify terminology
+    Select prefix input on modify terminology
     Input prefix ${DEFAULT TERMINOLOGY PREFIX}_1 on modify terminology
 
     Save terminology modify
@@ -168,14 +168,12 @@ T7C3. Verify modify terminology errors
     Remove selected status on modify terminology
     On modify terminology select organization Automaatiotestaus
     Select domain Asuminen on modify terminology
-    Select prefix manual on modify terminology
 
     Save terminology modify 
     ...  False
     Verify modify terminology error message ${Terminology modify status missing error}
     Verify modify terminology error message ${Terminology modify contributors missing error}
     Verify modify terminology error message ${Terminology modify domain missing error}
-    Verify modify terminology error message ${Terminology modify prefix missing error}
 
     Select status Voimassa oleva on modify terminology
     On modify terminology select organization Automaatiotestaus

--- a/tests/terminology/terminology_search_page_terminology.robot
+++ b/tests/terminology/terminology_search_page_terminology.robot
@@ -101,6 +101,8 @@ T2C3. Test and create terminology with concepts
     [Teardown]  Teardown test Case delete terminology ${DEFAULT TERMINOLOGY NAME}
 
 T2C4. Test and create terminology with collection containin concepts and without concepts
+    # TODO: remove skip and fix final verification check after the fix from YTI-4388 has been implemented
+    Skip
     Create terminology with api     ${DEFAULT TERMINOLOGY NAME}
     ...                             ${DRAFT}
     ...                             ${DOMAIN HOUSING}

--- a/tests/terminology/terminology_search_page_terminology.robot
+++ b/tests/terminology/terminology_search_page_terminology.robot
@@ -130,7 +130,7 @@ T2C4. Test and create terminology with collection containin concepts and without
     Verify collection ${DEFAULT COLLECTION NAME} containing concept ${DEFAULT CONCEPT NAME}_2 on terminology ${DEFAULT TERMINOLOGY NAME}
 
     ${emptylist}=                           Create List
-    Create terminology collection with api  ${DEFAULT TERMINOLOGY NAME}
+    Update terminology collection with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                     ${DEFAULT COLLECTION NAME}
     ...                                     ${COLLECTION ID DEFAULT}
     ...                                     ${emptylist}

--- a/tests/terminology/terminology_search_page_terminology.robot
+++ b/tests/terminology/terminology_search_page_terminology.robot
@@ -59,27 +59,23 @@ T2C3. Test and create terminology with concepts
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}_1
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
     
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}_2
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce2
+    ...                                  concept-2
     ...                                  ${VALID}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e82
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}_3
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce3
+    ...                                  concept-3
     ...                                  ${SUPERSEDED}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e83
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}_4
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce4
+    ...                                  concept-4
     ...                                  ${RETIRED}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e84
 
     Open terminology search page
     Search and select terminology ${DEFAULT TERMINOLOGY NAME}
@@ -113,17 +109,15 @@ T2C4. Test and create terminology with collection containin concepts and without
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}_1
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce1
+    ...                                  concept-1
     ...                                  ${DRAFT}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e81
 
     Create terminology concept with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                  ${DEFAULT CONCEPT NAME}_2
-    ...                                  04bb2206-ba9e-4007-920d-f57ed0d4bce2
+    ...                                  concept-2
     ...                                  ${VALID}
-    ...                                  bf5f88cb-3a33-498e-b8eb-1c9807973e82
 
-    ${members}=    Create List              04bb2206-ba9e-4007-920d-f57ed0d4bce1       04bb2206-ba9e-4007-920d-f57ed0d4bce2
+    ${members}=    Create List              concept-1       concept-2
     Create terminology collection with api  ${DEFAULT TERMINOLOGY NAME}
     ...                                     ${DEFAULT COLLECTION NAME}
     ...                                     ${COLLECTION ID DEFAULT}


### PR DESCRIPTION
This PR brings the robot tests up to date with the current implementation of the services. It fixes tens of tests and adds a few skips where fixing is needed in the tested service instead.

- Terminology API usage changed to reflect the current API instead of the old one
- Tens of tests fixed
- A few tests skipped due to fixes needed in the services themselves (task ID:s mentioned in the skip comments)